### PR TITLE
Adding try-catch to STARTUPINFO()

### DIFF
--- a/autoload/bg.vim
+++ b/autoload/bg.vim
@@ -163,12 +163,15 @@ class MyThread ( threading.Thread ):
     self.command = cmd
     self.tmpfile = tmpfile
     self.callback_nr = callback_nr
-
-    self.su = subprocess.STARTUPINFO()
-    if subprocess.mswindows:
-      self.su.dwFlags |= subprocess._subprocess.STARTF_USESHOWWINDOW
-      self.su.wShowWindow = subprocess._subprocess.SW_HIDE
-
+    
+    try:
+      self.su = subprocess.STARTUPINFO()
+      if subprocess.mswindows:
+        self.su.dwFlags |= subprocess._subprocess.STARTF_USESHOWWINDOW
+        self.su.wShowWindow = subprocess._subprocess.SW_HIDE
+    except:
+      pass
+    
   def run ( self ):
     try:
       if type(self.command) == type(""):

--- a/autoload/bg.vim
+++ b/autoload/bg.vim
@@ -164,6 +164,7 @@ class MyThread ( threading.Thread ):
     self.tmpfile = tmpfile
     self.callback_nr = callback_nr
     
+    #on some machines STARTUPINFO is not defined
     try:
       self.su = subprocess.STARTUPINFO()
       if subprocess.mswindows:


### PR DESCRIPTION
On my computer (MacOS 10.10.5, python 2.7.10), subprocess module does not support STARTUPINFO. Adding try-catch prevents the code from crashing.

```
>>> import subprocess
>>> subprocess.STARTUPINFO()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'STARTUPINFO'
>>>
```
